### PR TITLE
Use defer to reset to original namespace, better log errors

### DIFF
--- a/rdma_stats.go
+++ b/rdma_stats.go
@@ -181,16 +181,20 @@ func GetDockerContainerRdmaStats(containerID string) {
 
 	nsHandle, err := netns.GetFromDocker(containerID)
 	if err != nil {
-		log.Println("Invalid docker id: ", containerID)
-		return
-	}
-	if netns.Set(nsHandle) != nil {
+		log.Printf("Invalid docker id (\"%s\"): %v", containerID, err)
 		return
 	}
 
+	err = netns.Set(nsHandle)
+	if err != nil {
+		log.Println("Fail to set namespace: ", err)
+		return
+	}
+	defer netns.Set(originalHandle)
+
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		_ = netns.Set(originalHandle)
+		log.Println("Fail to get Net Interfaces: ", err)
 		return
 	}
 	log.Printf("Net Interfaces: %v\n", ifaces)
@@ -209,5 +213,4 @@ func GetDockerContainerRdmaStats(containerID string) {
 		}
 		printRdmaStats(rdmadev, &rdmastats)
 	}
-	_ = netns.Set(originalHandle)
 }


### PR DESCRIPTION
This PR aims the following:
- improves error logging for better understanding the cause of `netns`'s failures by printing `err` value in case of some `netns`'s procedure fails;
- decreases code duplication, improves readability and makes code less error-prone by using `defer netns.Set(originalHandle)` instead of calling `netns.Set(originalHandle)` twice to reset a network namespace.

Signed-off-by: Dmitrii Gabor <dmitryg1709@gmail.com>