### PR TITLE
Add function to retrieve port GUID from GID file and update device matching logic

### DIFF
--- a/rdma_map.go
+++ b/rdma_map.go
@@ -37,6 +37,12 @@ const (
 	nibbleBitSize  = 4
 	loopBackIfName = "lo"
 
+	// GID format constants
+	gidParts            = 8 // Number of colon-separated parts in a GID
+	portGUIDStartIndex  = 4 // Port GUID starts at index 4 in the GID parts
+	gidPartLength       = 4 // Each GID part is 4 hex characters
+	hexBytePairLength   = 2 // 2 hex characters represent 1 byte
+
 	ReadOnlyPermissions = 0444
 )
 
@@ -352,24 +358,24 @@ func getPortGUID(rdmaDeviceName, port string) ([]byte, error) {
 	// Parse GID format: "fe80:0000:0000:0000:0015:5dff:fd34:025b\n"
 	gidStr := strings.TrimSpace(string(data))
 	parts := strings.Split(gidStr, ":")
-	if len(parts) != 8 {
+	if len(parts) != gidParts {
 		return nil, fmt.Errorf("invalid GID format: %s", gidStr)
 	}
 
 	// Extract last 4 groups (8 bytes) which represent the port GUID
 	var portGUID []byte
-	for i := 4; i < 8; i++ {
+	for i := portGUIDStartIndex; i < gidParts; i++ {
 		// Each part is 4 hex digits (2 bytes)
-		if len(parts[i]) != 4 {
+		if len(parts[i]) != gidPartLength {
 			return nil, fmt.Errorf("invalid GID part: %s", parts[i])
 		}
 		// Parse first byte
-		b1, err := strconv.ParseUint(parts[i][0:2], 16, 8)
+		b1, err := strconv.ParseUint(parts[i][0:hexBytePairLength], 16, 8)
 		if err != nil {
 			return nil, err
 		}
 		// Parse second byte
-		b2, err := strconv.ParseUint(parts[i][2:4], 16, 8)
+		b2, err := strconv.ParseUint(parts[i][hexBytePairLength:gidPartLength], 16, 8)
 		if err != nil {
 			return nil, err
 		}

--- a/rdma_map.go
+++ b/rdma_map.go
@@ -25,6 +25,7 @@ const (
 	RdmaGidAttrDir     = "gid_attrs" //nolint:stylecheck,revive
 	RdmaGidAttrNdevDir = "ndevs"     //nolint:stylecheck,revive
 	RdmaPortsdir       = "ports"
+	RdmaGidsDir        = "gids"
 
 	RdmaNodeGuidFile = "node_guid" //nolint:stylecheck,revive
 
@@ -327,18 +328,74 @@ func getNodeGUID(rdmaDeviceName string) ([]byte, error) {
 	return nodeGUID, nil
 }
 
+func getPortGUID(rdmaDeviceName, port string) ([]byte, error) {
+	// Read the GID from port's gids/0
+	// The GID format is: fe80:0000:0000:0000:PPPP:PPPP:PPPP:PPPP
+	// where the last 8 bytes (64 bits) are the port GUID
+	fileName := filepath.Join(RdmaClassDir, rdmaDeviceName, RdmaPortsdir, port, RdmaGidsDir, "0")
+
+	fd, err := os.OpenFile(fileName, os.O_RDONLY, ReadOnlyPermissions)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	if _, err = fd.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	data, err := io.ReadAll(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse GID format: "fe80:0000:0000:0000:0015:5dff:fd34:025b\n"
+	gidStr := strings.TrimSpace(string(data))
+	parts := strings.Split(gidStr, ":")
+	if len(parts) != 8 {
+		return nil, fmt.Errorf("invalid GID format: %s", gidStr)
+	}
+
+	// Extract last 4 groups (8 bytes) which represent the port GUID
+	var portGUID []byte
+	for i := 4; i < 8; i++ {
+		// Each part is 4 hex digits (2 bytes)
+		if len(parts[i]) != 4 {
+			return nil, fmt.Errorf("invalid GID part: %s", parts[i])
+		}
+		// Parse first byte
+		b1, err := strconv.ParseUint(parts[i][0:2], 16, 8)
+		if err != nil {
+			return nil, err
+		}
+		// Parse second byte
+		b2, err := strconv.ParseUint(parts[i][2:4], 16, 8)
+		if err != nil {
+			return nil, err
+		}
+		portGUID = append(portGUID, byte(b1), byte(b2))
+	}
+
+	return portGUID, nil
+}
+
 func getRdmaDeviceForIb(linkAttr *netlink.LinkAttrs) (string, error) {
-	// Match the node_guid EUI bytes with the IpoIB netdevice hw address EUI
+	// Match the port GUID EUI bytes with the IpoIB netdevice hw address EUI
+	// IPoIB hardware addresses encode the port GUID, not the node GUID
 	lleui64 := linkAttr.HardwareAddr[12:]
 
 	devices := GetRdmaDeviceList()
 	for _, dev := range devices {
-		nodeGUID, err := getNodeGUID(dev)
-		if err != nil {
-			return "", err
-		}
-		if bytes.Equal(lleui64, nodeGUID) {
-			return dev, nil
+		ports := GetPorts(dev)
+		for _, port := range ports {
+			portGUID, err := getPortGUID(dev, port)
+			if err != nil {
+				// If we can't read the port GUID, skip this port
+				continue
+			}
+			if bytes.Equal(lleui64, portGUID) {
+				return dev, nil
+			}
 		}
 	}
 	return "", nil

--- a/rdma_test.go
+++ b/rdma_test.go
@@ -160,6 +160,102 @@ func TestGetRdmaCharDevices_MultiPort(t *testing.T) {
 	}
 }
 
+func TestGetRdmaUcmDevices_Found(t *testing.T) {
+	tmpDir := t.TempDir()
+	ucmFile := filepath.Join(tmpDir, "rdma_cm")
+	if err := os.WriteFile(ucmFile, []byte(""), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	origUcmDevice := RdmaUcmDevice
+	defer func() { RdmaUcmDevice = origUcmDevice }()
+	RdmaUcmDevice = ucmFile
+
+	devices := getRdmaUcmDevices()
+	if len(devices) != 1 {
+		t.Fatalf("expected 1 device, got %d: %v", len(devices), devices)
+	}
+	if devices[0] != ucmFile {
+		t.Errorf("got %q, want %q", devices[0], ucmFile)
+	}
+}
+
+func TestGetRdmaUcmDevices_NotFound(t *testing.T) {
+	origUcmDevice := RdmaUcmDevice
+	defer func() { RdmaUcmDevice = origUcmDevice }()
+	RdmaUcmDevice = "/nonexistent/rdma_cm"
+
+	devices := getRdmaUcmDevices()
+	if devices != nil {
+		t.Errorf("expected nil, got %v", devices)
+	}
+}
+
+func TestGetRdmaUcmDevices_WrongName(t *testing.T) {
+	tmpDir := t.TempDir()
+	wrongFile := filepath.Join(tmpDir, "not_rdma_cm")
+	if err := os.WriteFile(wrongFile, []byte(""), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	origUcmDevice := RdmaUcmDevice
+	defer func() { RdmaUcmDevice = origUcmDevice }()
+	RdmaUcmDevice = wrongFile
+
+	devices := getRdmaUcmDevices()
+	if devices != nil {
+		t.Errorf("expected nil, got %v", devices)
+	}
+}
+
+func TestGetRdmaCharDevices_WithRdmaCm(t *testing.T) {
+	ucmDir := t.TempDir()
+	umadDir := t.TempDir()
+	uverbsDir := t.TempDir()
+	rdmaCmDir := t.TempDir()
+	rdmaCmFile := filepath.Join(rdmaCmDir, "rdma_cm")
+	if err := os.WriteFile(rdmaCmFile, []byte(""), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	origUcmDir := RdmaIbUcmDir
+	origUmadDir := RdmaUmadDir
+	origUverbsDir := RdmaUverbsDir
+	origUcmDevice := RdmaUcmDevice
+	defer func() {
+		RdmaIbUcmDir = origUcmDir
+		RdmaUmadDir = origUmadDir
+		RdmaUverbsDir = origUverbsDir
+		RdmaUcmDevice = origUcmDevice
+	}()
+	RdmaIbUcmDir = ucmDir
+	RdmaUmadDir = umadDir
+	RdmaUverbsDir = uverbsDir
+	RdmaUcmDevice = rdmaCmFile
+
+	createFakeSysfsDevice(t, umadDir, "umad0", "mlx5_0")
+	createFakeSysfsDevice(t, uverbsDir, "uverbs0", "mlx5_0")
+
+	devices := GetRdmaCharDevices("mlx5_0")
+	sort.Strings(devices)
+
+	expected := []string{
+		rdmaCmFile,
+		"/dev/infiniband/umad0",
+		"/dev/infiniband/uverbs0",
+	}
+	sort.Strings(expected)
+
+	if len(devices) != len(expected) {
+		t.Fatalf("expected %d devices, got %d: %v", len(expected), len(devices), devices)
+	}
+	for i := range expected {
+		if devices[i] != expected[i] {
+			t.Errorf("device[%d] = %q, want %q", i, devices[i], expected[i])
+		}
+	}
+}
+
 func TestGetRdmaCharDevices_NoDevices(t *testing.T) {
 	emptyDir := t.TempDir()
 


### PR DESCRIPTION
This pull request updates the logic for matching RDMA devices to IB network interfaces by switching from using the node GUID to using the port GUID, which more accurately reflects the hardware address encoding. The changes introduce a new function to extract the port GUID from the device's GID file and update the matching process accordingly.

**RDMA device and port GUID handling:**

* Added a new constant `RdmaGidsDir` to represent the `gids` directory for easier path construction.
* Introduced the `getPortGUID` function to read and parse the port GUID from the device's GID file (`gids/0`). This function extracts the last 8 bytes of the GID as the port GUID.
* Updated `getRdmaDeviceForIb` to use the port GUID for matching instead of the node GUID, iterating over all ports of each device. This ensures correct association between IB hardware addresses and RDMA devices.

fix #15