### PR TITLE
 feat: Add support for multi-port RDMA devices

### DIFF
--- a/rdma_map.go
+++ b/rdma_map.go
@@ -99,17 +99,18 @@ func isDirForRdmaDevice(rdmaDeviceName, dirName string) bool {
 	return strings.Trim(string(data), "\n") == rdmaDeviceName
 }
 
-func getCharDevice(rdmaDeviceName, classDir, charDevPrefix string) (string, error) {
+func getCharDevices(rdmaDeviceName, classDir, charDevPrefix string) []string {
 	fd, err := os.Open(classDir)
 	if err != nil {
-		return "", err
+		return nil
 	}
 	defer fd.Close()
 	fileInfos, err := fd.Readdir(-1)
 	if err != nil {
-		return "", nil
+		return nil
 	}
 
+	devices := make([]string, 0, len(fileInfos))
 	for i := range fileInfos {
 		if fileInfos[i].Name() == "." || fileInfos[i].Name() == prevDir {
 			continue
@@ -121,74 +122,41 @@ func getCharDevice(rdmaDeviceName, classDir, charDevPrefix string) (string, erro
 		if !isDirForRdmaDevice(rdmaDeviceName, dirName) {
 			continue
 		}
-		deviceFile := filepath.Join("/dev/infiniband", fileInfos[i].Name()) //nolint:gocritic
-		return deviceFile, nil
+		devices = append(devices, filepath.Join(RdmaDeviceDir, fileInfos[i].Name()))
 	}
-	return "", fmt.Errorf("no ucm device found")
+	return devices
 }
 
-func getUcmDevice(rdmaDeviceName string) (string, error) {
-	return getCharDevice(rdmaDeviceName,
-		RdmaIbUcmDir,
-		RdmaUcmFilePrefix)
-}
-
-func getIssmDevice(rdmaDeviceName string) (string, error) {
-	return getCharDevice(rdmaDeviceName,
-		RdmaUmadDir,
-		RdmaIssmFilePrefix)
-}
-
-func getUmadDevice(rdmaDeviceName string) (string, error) {
-	return getCharDevice(rdmaDeviceName,
-		RdmaUmadDir,
-		RdmaUmadFilxPrefix)
-}
-
-func getUverbDevice(rdmaDeviceName string) (string, error) {
-	return getCharDevice(rdmaDeviceName,
-		RdmaUverbsDir,
-		RdmaUverbsFilxPrefix)
-}
-
-func getRdmaUcmDevice() (string, error) {
+func getRdmaUcmDevices() []string {
 	info, err := os.Stat(RdmaUcmDevice)
 	if err != nil {
-		return "", err
+		return nil
 	}
 	if info.Name() == "rdma_cm" {
-		return RdmaUcmDevice, nil
+		return []string{RdmaUcmDevice}
 	}
-
-	return "", fmt.Errorf("invalid file name rdma_cm")
+	return nil
 }
 
-// Returns a list of character device absolute path for a requested
-// rdmaDeviceName.
+// GetRdmaCharDevices returns a list of character device absolute paths for a
+// requested rdmaDeviceName. For multi-port RDMA devices, all matching
+// character devices of each type are returned (e.g., all umad and issm
+// devices across all ports).
 // Returns nil if no character devices are found.
 func GetRdmaCharDevices(rdmaDeviceName string) []string {
 	var rdmaCharDevices []string
 
-	ucm, err := getUcmDevice(rdmaDeviceName)
-	if err == nil {
-		rdmaCharDevices = append(rdmaCharDevices, ucm)
-	}
-	issm, err := getIssmDevice(rdmaDeviceName)
-	if err == nil {
-		rdmaCharDevices = append(rdmaCharDevices, issm)
-	}
-	umad, err := getUmadDevice(rdmaDeviceName)
-	if err == nil {
-		rdmaCharDevices = append(rdmaCharDevices, umad)
-	}
-	uverb, err := getUverbDevice(rdmaDeviceName)
-	if err == nil {
-		rdmaCharDevices = append(rdmaCharDevices, uverb)
-	}
-	rdmaCm, err := getRdmaUcmDevice()
-	if err == nil {
-		rdmaCharDevices = append(rdmaCharDevices, rdmaCm)
-	}
+	rdmaCharDevices = append(rdmaCharDevices,
+		getCharDevices(rdmaDeviceName, RdmaIbUcmDir, RdmaUcmFilePrefix)...)
+	rdmaCharDevices = append(rdmaCharDevices,
+		getCharDevices(rdmaDeviceName, RdmaUmadDir, RdmaIssmFilePrefix)...)
+	rdmaCharDevices = append(rdmaCharDevices,
+		getCharDevices(rdmaDeviceName, RdmaUmadDir, RdmaUmadFilxPrefix)...)
+	rdmaCharDevices = append(rdmaCharDevices,
+		getCharDevices(rdmaDeviceName, RdmaUverbsDir, RdmaUverbsFilxPrefix)...)
+
+	rdmaCharDevices = append(rdmaCharDevices,
+		getRdmaUcmDevices()...)
 
 	return rdmaCharDevices
 }

--- a/rdma_test.go
+++ b/rdma_test.go
@@ -2,6 +2,9 @@ package rdmamap
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
 	"testing"
 )
 
@@ -18,6 +21,166 @@ func TestRdmaCharDevices(t *testing.T) {
 		charDevices := GetRdmaCharDevices(dev)
 		fmt.Printf("Rdma device: = %s", dev)
 		t.Log(" Char devices: = ", charDevices)
+	}
+}
+
+// createFakeSysfsDevice creates a subdirectory under classDir named entryName
+// with an "ibdev" file containing rdmaDeviceName.
+func createFakeSysfsDevice(t *testing.T, classDir, entryName, rdmaDeviceName string) {
+	t.Helper()
+	dir := filepath.Join(classDir, entryName)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ibdev"), []byte(rdmaDeviceName+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetCharDevices_MultipleDevices(t *testing.T) {
+	classDir := t.TempDir()
+	createFakeSysfsDevice(t, classDir, "umad0", "mlx5_0")
+	createFakeSysfsDevice(t, classDir, "umad1", "mlx5_0")
+
+	devices := getCharDevices("mlx5_0", classDir, "umad")
+	sort.Strings(devices)
+
+	expected := []string{
+		"/dev/infiniband/umad0",
+		"/dev/infiniband/umad1",
+	}
+	if len(devices) != len(expected) {
+		t.Fatalf("expected %d devices, got %d: %v", len(expected), len(devices), devices)
+	}
+	for i := range expected {
+		if devices[i] != expected[i] {
+			t.Errorf("device[%d] = %q, want %q", i, devices[i], expected[i])
+		}
+	}
+}
+
+func TestGetCharDevices_FiltersByPrefix(t *testing.T) {
+	classDir := t.TempDir()
+	createFakeSysfsDevice(t, classDir, "umad0", "mlx5_0")
+	createFakeSysfsDevice(t, classDir, "issm0", "mlx5_0")
+
+	devices := getCharDevices("mlx5_0", classDir, "umad")
+	if len(devices) != 1 {
+		t.Fatalf("expected 1 device, got %d: %v", len(devices), devices)
+	}
+	if devices[0] != "/dev/infiniband/umad0" {
+		t.Errorf("got %q, want /dev/infiniband/umad0", devices[0])
+	}
+}
+
+func TestGetCharDevices_FiltersByRdmaDevice(t *testing.T) {
+	classDir := t.TempDir()
+	createFakeSysfsDevice(t, classDir, "umad0", "mlx5_0")
+	createFakeSysfsDevice(t, classDir, "umad1", "mlx5_1")
+
+	devices := getCharDevices("mlx5_0", classDir, "umad")
+	if len(devices) != 1 {
+		t.Fatalf("expected 1 device, got %d: %v", len(devices), devices)
+	}
+	if devices[0] != "/dev/infiniband/umad0" {
+		t.Errorf("got %q, want /dev/infiniband/umad0", devices[0])
+	}
+}
+
+func TestGetCharDevices_NonexistentDir(t *testing.T) {
+	devices := getCharDevices("mlx5_0", "/nonexistent/path", "umad")
+	if devices != nil {
+		t.Errorf("expected nil, got %v", devices)
+	}
+}
+
+func TestGetCharDevices_EmptyDir(t *testing.T) {
+	classDir := t.TempDir()
+	devices := getCharDevices("mlx5_0", classDir, "umad")
+	if len(devices) != 0 {
+		t.Errorf("expected empty slice, got %v", devices)
+	}
+}
+
+func TestGetCharDevices_ReturnsNilWhenNoMatch(t *testing.T) {
+	classDir := t.TempDir()
+	createFakeSysfsDevice(t, classDir, "issm0", "mlx5_0")
+
+	devices := getCharDevices("mlx5_0", classDir, "umad")
+	if len(devices) != 0 {
+		t.Errorf("expected no devices, got %v", devices)
+	}
+}
+
+func TestGetRdmaCharDevices_MultiPort(t *testing.T) {
+	ucmDir := t.TempDir()
+	umadDir := t.TempDir()
+	uverbsDir := t.TempDir()
+
+	origUcmDir := RdmaIbUcmDir
+	origUmadDir := RdmaUmadDir
+	origUverbsDir := RdmaUverbsDir
+	origUcmDevice := RdmaUcmDevice
+	defer func() {
+		RdmaIbUcmDir = origUcmDir
+		RdmaUmadDir = origUmadDir
+		RdmaUverbsDir = origUverbsDir
+		RdmaUcmDevice = origUcmDevice
+	}()
+	RdmaIbUcmDir = ucmDir
+	RdmaUmadDir = umadDir
+	RdmaUverbsDir = uverbsDir
+	RdmaUcmDevice = "/nonexistent/rdma_cm"
+
+	createFakeSysfsDevice(t, ucmDir, "ucm0", "mlx5_0")
+	createFakeSysfsDevice(t, umadDir, "issm0", "mlx5_0")
+	createFakeSysfsDevice(t, umadDir, "issm1", "mlx5_0")
+	createFakeSysfsDevice(t, umadDir, "umad0", "mlx5_0")
+	createFakeSysfsDevice(t, umadDir, "umad1", "mlx5_0")
+	createFakeSysfsDevice(t, uverbsDir, "uverbs0", "mlx5_0")
+
+	devices := GetRdmaCharDevices("mlx5_0")
+	sort.Strings(devices)
+
+	expected := []string{
+		"/dev/infiniband/issm0",
+		"/dev/infiniband/issm1",
+		"/dev/infiniband/ucm0",
+		"/dev/infiniband/umad0",
+		"/dev/infiniband/umad1",
+		"/dev/infiniband/uverbs0",
+	}
+	if len(devices) != len(expected) {
+		t.Fatalf("expected %d devices, got %d: %v", len(expected), len(devices), devices)
+	}
+	for i := range expected {
+		if devices[i] != expected[i] {
+			t.Errorf("device[%d] = %q, want %q", i, devices[i], expected[i])
+		}
+	}
+}
+
+func TestGetRdmaCharDevices_NoDevices(t *testing.T) {
+	emptyDir := t.TempDir()
+
+	origUcmDir := RdmaIbUcmDir
+	origUmadDir := RdmaUmadDir
+	origUverbsDir := RdmaUverbsDir
+	origUcmDevice := RdmaUcmDevice
+	defer func() {
+		RdmaIbUcmDir = origUcmDir
+		RdmaUmadDir = origUmadDir
+		RdmaUverbsDir = origUverbsDir
+		RdmaUcmDevice = origUcmDevice
+	}()
+	RdmaIbUcmDir = emptyDir
+	RdmaUmadDir = emptyDir
+	RdmaUverbsDir = emptyDir
+	RdmaUcmDevice = "/nonexistent/rdma_cm"
+
+	devices := GetRdmaCharDevices("mlx5_0")
+	if len(devices) != 0 {
+		t.Errorf("expected no devices, got %v", devices)
 	}
 }
 


### PR DESCRIPTION
Previously, GetRdmaCharDevices only returned the first matching character device of each type (umad, issm, ucm, uverbs). For multi-port RDMA devices, this meant only one umad/issm/etc. device was returned instead of all of them.

Extract getCharDevices() that returns all matching devices, and have GetRdmaCharDevices call it directly.

Add unit tests covering multi-device returns, prefix filtering, RDMA device filtering, and end-to-end GetRdmaCharDevices aggregation.

Issue have detected on ConnectX 8 XDR