### PR TITLE
Update Go to 1.25, golangci-lint to v2

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore:"
+
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    commit-message:
+      prefix: "chore:"

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -7,18 +7,18 @@ jobs:
     name: build
     strategy:
       matrix:
-        go-version: [1.20.x]
-        os: [ubuntu-22.04]
+        go-version: [1.25.x]
+        os: [ubuntu-24.04]
         goos: [linux]
         goarch: [amd64]
     runs-on: ${{ matrix.os }}
     steps:
       - name: set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
       - name: check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: build test for ${{ matrix.goarch }}
         env:
           GOARCH: ${{ matrix.goarch }}
@@ -27,29 +27,29 @@ jobs:
    
   test:
     name: test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build
     steps:
       - name: set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.20.x
+          go-version: 1.25.x
       - name: check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: run unit-test
         run: make test
 
   coverage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build
     name: coverage
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.20.x
+          go-version: 1.25.x
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Go test with coverage
         run: make test-coverage
       - name: Coveralls

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,98 +1,99 @@
-linters-settings:
-  dupl:
-    threshold: 150
-  funlen:
-    lines: 100
-    statements: 50
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-      - wrapperFunc
-      - unnamedResult
-  gocognit:
-    min-complexity: 30
-  goimports:
-    local-prefixes: github.com/Mellanox/rdmamap
-  golint:
-    min-confidence: 0
-  gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: argument,case,condition,return
-  govet:
-    check-shadowing: true
-    settings:
-      printf:
-        funcs:
-          - (github.com/rs/zerolog/zerolog.Event).Msgf
-  lll:
-    line-length: 120
-  misspell:
-    locale: US
-  prealloc:
-    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
-    # True by default.
-    simple: true
-    range-loops: true # Report preallocation suggestions on range loops, true by default
-    for-loops: false # Report preallocation suggestions on for loops, false by default
+version: "2"
 
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
     - funlen
     - gochecknoinits
     - goconst
     - gocritic
     - gocognit
-    - gofmt
-    - goimports
-    - gomnd
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
+    - mnd
     - nakedret
     - prealloc
     - rowserrcheck
     - staticcheck
-    - stylecheck
-    - typecheck
     - revive
     - unconvert
     - unparam
     - unused
     - whitespace
+  settings:
+    dupl:
+      threshold: 150
+    funlen:
+      lines: 100
+      statements: 50
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      disabled-checks:
+        - dupImport # https://github.com/go-critic/go-critic/issues/845
+        - ifElseChain
+        - octalLiteral
+        - whyNoLint
+        - wrapperFunc
+        - unnamedResult
+    gocognit:
+      min-complexity: 30
+    govet:
+      enable:
+        - shadow
+      settings:
+        printf:
+          funcs:
+            - (github.com/rs/zerolog/zerolog.Event).Msgf
+    lll:
+      line-length: 120
+    misspell:
+      locale: US
+    mnd:
+      checks:
+        - argument
+        - case
+        - condition
+        - return
+    prealloc:
+      simple: true
+      range-loops: true
+      for-loops: false
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: _test\.go
+        linters:
+          - mnd
+          - goconst
+      - text: "Magic number: 1"
+        linters:
+          - mnd
 
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gomnd
-        - goconst
-    - text: "Magic number: 1"
-      linters:
-        - gomnd
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/Mellanox/rdmamap

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GOLANGCI_LINT = $(GOBIN)/golangci-lint
 # golangci-lint version should be updated periodically
 # we keep it fixed to avoid it from unexpectedly failing on the project
 # in case of a version bump
-GOLANGCI_LINT_VER = v1.53.3
+GOLANGCI_LINT_VER = v2.11.4
 TIMEOUT = 15
 Q = $(if $(filter 1,$V),,@)
 
@@ -37,7 +37,7 @@ build: $(GOFILES)
 # Tools
 
 $(GOLANGCI_LINT): ; $(info  building golangci-lint...)
-	$Q curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) $(GOLANGCI_LINT_VER)
+	$Q curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOBIN) $(GOLANGCI_LINT_VER)
 
 GOVERALLS = $(GOBIN)/goveralls
 $(GOBIN)/goveralls:  $(BASE)  $(GOBIN) ; $(info  building goveralls...)

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/Mellanox/rdmamap
 
-go 1.20
+go 1.25.0
 
 require (
-	github.com/vishvananda/netlink v1.1.0
-	github.com/vishvananda/netns v0.0.4
+	github.com/vishvananda/netlink v1.3.1
+	github.com/vishvananda/netns v0.0.5
 )
 
-require golang.org/x/sys v0.10.0 // indirect
+require golang.org/x/sys v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
-github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
-github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
-github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
-github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
-golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
+github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
+github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
+github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/rdma_map.go
+++ b/rdma_map.go
@@ -22,11 +22,11 @@ const (
 
 	RdmaUverbsFilxPrefix = "uverbs"
 
-	RdmaGidAttrDir     = "gid_attrs" //nolint:stylecheck,revive
-	RdmaGidAttrNdevDir = "ndevs"     //nolint:stylecheck,revive
+	RdmaGidAttrDir     = "gid_attrs" //nolint:revive
+	RdmaGidAttrNdevDir = "ndevs"     //nolint:revive
 	RdmaPortsdir       = "ports"
 
-	RdmaNodeGuidFile = "node_guid" //nolint:stylecheck,revive
+	RdmaNodeGuidFile = "node_guid" //nolint:revive
 
 	RdmaCountersDir   = "counters"
 	RdmaHwCountersDir = "hw_counters"
@@ -221,7 +221,7 @@ func GetPorts(rdmaDeviceName string) []string {
 }
 
 //nolint:prealloc
-func getNetdeviceIds(rdmaDeviceName, port string) []string {
+func getNetdeviceIDs(rdmaDeviceName, port string) []string {
 	var indices []string
 
 	dir := filepath.Join(RdmaClassDir, rdmaDeviceName, RdmaPortsdir, port,
@@ -277,7 +277,7 @@ func getRdmaDeviceForEth(netdevName string) (string, error) {
 	for _, dev := range devices {
 		ports := GetPorts(dev)
 		for _, port := range ports {
-			indices := getNetdeviceIds(dev, port)
+			indices := getNetdeviceIDs(dev, port)
 			for _, index := range indices {
 				found := isNetdevForRdma(dev, port, index, netdevName)
 				if found {
@@ -351,11 +351,12 @@ func GetRdmaDeviceForNetdevice(netdevName string) (string, error) {
 		return "", err
 	}
 	netAttr := handle.Attrs()
-	if netAttr.EncapType == "ether" {
+	switch netAttr.EncapType {
+	case "ether":
 		return getRdmaDeviceForEth(netdevName)
-	} else if netAttr.EncapType == "infiniband" {
+	case "infiniband":
 		return getRdmaDeviceForIb(netAttr)
-	} else {
+	default:
 		return "", fmt.Errorf("unknown device type")
 	}
 }


### PR DESCRIPTION
- Bump Go from 1.20 to 1.25; update dependencies (netlink v1.3.1, netns v0.0.5, x/sys v0.42.0)
- Migrate golangci-lint from v1.53.3 to v2.11.4 with v2 config format
- Update GitHub Actions: setup-go@v6, checkout@v6, ubuntu-24.04
- Add dependabot config
- Fix lint issues: rename getNetdeviceIds to getNetdeviceIDs, refactor if/else chain to switch, remove stale nolint directives